### PR TITLE
Ability to set the starting index of the image viewer

### DIFF
--- a/BFRImageViewController/BFRImageViewController.h
+++ b/BFRImageViewController/BFRImageViewController.h
@@ -22,10 +22,9 @@
 /*! When peeking, iOS already hides the status bar for you. In that case, leave this to the default value of NO. If you are using this class outside of 3D touch, set this to YES. */
 @property (nonatomic, getter=shouldHideStatusBar) BOOL hideStatusBar;
 
-/*! Flag property that toggles the doneButton. Defaults to YES */
+/*! Flag property that lets disable the doneButton. Default to YES */
 @property (nonatomic) BOOL enableDoneButton;
 
-/*! Flag property that sets the doneButton position (left or right side). Defaults to YES */
-@property (nonatomic) BOOL showDoneButtonOnLeft;
+@property (nonatomic, assign) NSInteger startingIndex;
 
 @end


### PR DESCRIPTION
Previously the image viewer would always initially show the first image.  If you have a collection of images and tap the 4th image in your collection, you should have the option of showing that image instead.
