### PR TITLE
Fix #83: Don't ever display status bar if presenting view controller didn't.

### DIFF
--- a/BFRImageViewController/BFRImageViewController.m
+++ b/BFRImageViewController/BFRImageViewController.m
@@ -107,7 +107,11 @@
 
 #pragma mark - Status bar
 
-- (BOOL)prefersStatusBarHidden{
+- (BOOL)prefersStatusBarHidden {
+    if (self.presentingViewController.prefersStatusBarHidden) {
+        return YES;
+    }
+    
     return self.shouldHideStatusBar;
 }
 


### PR DESCRIPTION
Without this fix, the status bar would briefly be presented (and then immediately dismissed) during the transition animation to display an image. More importantly, this would cause the y-position of the original image to be off by the height of the status bar during the transition animation, causing a distracting jump.

The fix is to never request the status bar to be displayed, if the presenting view controller was not presenting a status bar.

Fixed version of the GIF from the issue:
![fixed](https://user-images.githubusercontent.com/227043/52887860-56c99000-3147-11e9-945b-106540ac4ad3.gif)
