### PR TITLE
Fix done button not loading when subclassing BFRImageViewController

### DIFF
--- a/BFRImageViewController/BFRImageViewController.m
+++ b/BFRImageViewController/BFRImageViewController.m
@@ -199,7 +199,7 @@
 
 - (void)addChromeToUI {
     if (self.enableDoneButton) {
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        NSBundle *bundle = [NSBundle bundleForClass:[BFRImageViewController class]];
         NSString *imagePath = [bundle pathForResource:@"cross" ofType:@"png"];
         UIImage *crossImage = [[UIImage alloc] initWithContentsOfFile:imagePath];
 


### PR DESCRIPTION
When subclassing `BFRImageViewController`, that `bundleForClass:[self class]` gets the bundle of the subclass, not the bundle for `BFRImageViewController`. This change should always load the bundle for `BFRImageViewController` so the done button always loads properly.