### PR TITLE
fix: Avoid dragging downwards or upwards to close the image(especially for the portrait image) when enlarge it to preview on iOS devices.

### DIFF
--- a/BFRImageViewController/BFRImageContainerViewController.h
+++ b/BFRImageViewController/BFRImageContainerViewController.h
@@ -37,9 +37,6 @@ typedef NS_ENUM(NSUInteger, BFRImageAssetType) {
 /*! Assigning YES to this property will disable long pressing media to present the activity view controller. You typically don't set this property yourself, instead, the value is derived from the containing @c BFRImageViewController instance. */
 @property (nonatomic, getter=shouldDisableSharingLongPress) BOOL disableSharingLongPress;
 
-/*! If there is more than one image in the containing @c BFRImageViewController - this property is set to YES to make swiping from image to image easier. */
-@property (nonatomic, getter=shouldDisableHorizontalDrag) BOOL disableHorizontalDrag;
-
 /*! Assigning YES to this property will disable autoplay for live photos when it used with 3DTouch peek feature */
 @property (nonatomic, getter=shouldDisableAutoplayForLivePhoto) BOOL disableAutoplayForLivePhoto;
 @property (nonatomic, assign) CGFloat imageMaxScale;

--- a/BFRImageViewController/BFRImageContainerViewController.m
+++ b/BFRImageViewController/BFRImageContainerViewController.m
@@ -224,9 +224,8 @@
     
     // Dragging to dismiss
     UIPanGestureRecognizer *panImg = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleDrag:)];
-    if (self.shouldDisableHorizontalDrag) {
-        panImg.delegate = self;
-    }
+    panImg.delegate = self;
+    
     [resizableImageView addGestureRecognizer:panImg];
     
     if (self.assetType == BFRImageAssetTypeLivePhoto) {

--- a/BFRImageViewController/BFRImageContainerViewController.m
+++ b/BFRImageViewController/BFRImageContainerViewController.m
@@ -266,6 +266,9 @@
 // If we have more than one image, this will cancel out dragging horizontally to make it easy to navigate between images
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
     CGPoint velocity = [(UIPanGestureRecognizer *)gestureRecognizer velocityInView:self.scrollView];
+    if (self.scrollView.zoomScale > 1) {
+        return  NO;
+    }
     return fabs(velocity.y) > fabs(velocity.x);
 }
 
@@ -370,7 +373,6 @@
             [self.animator removeAllBehaviors];
             self.activeAssetView.userInteractionEnabled = NO;
             self.scrollView.userInteractionEnabled = NO;
-            
             UIGravityBehavior *exitGravity = [[UIGravityBehavior alloc] initWithItems:@[self.activeAssetView]];
             if (CGRectContainsPoint(closeTopThreshhold, location)) {
                 exitGravity.gravityDirection = CGVectorMake(0.0, -1.0);

--- a/BFRImageViewController/BFRImageViewController.m
+++ b/BFRImageViewController/BFRImageViewController.m
@@ -184,7 +184,6 @@
         imgVC.usedFor3DTouch = self.isBeingUsedFor3DTouch;
         imgVC.useTransparentBackground = self.isUsingTransparentBackground;
         imgVC.disableSharingLongPress = self.shouldDisableSharingLongPress;
-        imgVC.disableHorizontalDrag = (self.images.count > 1);
         imgVC.disableAutoplayForLivePhoto = self.shouldDisableAutoplayForLivePhoto;
         imgVC.imageMaxScale = self.maxScale;
         [self.imageViewControllers addObject:imgVC];


### PR DESCRIPTION
Avoid dragging downwards or upwards to close the image(especially for the portrait image) when enlarge it to preview.